### PR TITLE
Remove the note on the clear/duplicate button

### DIFF
--- a/Novation/Novation-Launchpad.md
+++ b/Novation/Novation-Launchpad.md
@@ -52,7 +52,7 @@ Furthermore, some buttons were moved to a button which needs to be used in combi
 * **Shift+Delete** - Toggle repeat
 * **Quantise** - Quantises the selected clip.
 * **Record Quantise** - Press multiple times to toggle through the record quantisation settings.
-* **Duplicate** (**Clear** on the Pro Mk3) - Always duplicates the first selected clip on the current track if pressed with no other button.
+* **Duplicate** - Always duplicates the first selected clip on the current track if pressed with no other button.
   * To copy clips in Session mode on Pro models: Keep Duplicate button pressed; choose the source clip (it must be a clip with content, you can still select a different clip with content); select the destination clip (this must be an empty clip, which can also be on a different track); release the Duplicate button. On the non-pro models, activate duplicate mode, duplicate mode is deactivated, as soon as you select an empty clip as the destination.
   * Launchpad Pro: Keep the Duplicate button pressed and select a pad from the 1st row when a track mode is on to duplicate the track.
   * Launchpad Pro: Keep the Duplicate button pressed and select a scene to duplicate it.


### PR DESCRIPTION
It seems to me that the docs are incorrect - the duplicate button on mk3 works as duplicate and clear works as clear.