### PR TITLE
Minor clarification in Novation-Launchpad.md

### DIFF
--- a/Novation/Novation-Launchpad.md
+++ b/Novation/Novation-Launchpad.md
@@ -16,9 +16,9 @@ The following of Novation's Launchpad controllers are supported:
 * If the virtual faders (volume, pan, send, etc.) do not work, set the *Takeover mode* to *Immediate*.
 * If (Poly-)Aftertouch is not working (on devices which support it), check the global aftertouch settings of the Launchpad (check the Launchpad manual).
 
-If you added the controller manually, choose the following in-/output ports:
+If you added the controller manually, choose the following port for **both input and output**:
 
-* Pro Mk3: choose the 1st port (e.g. *LPProMK3 MIDI* on Windows).
+* Pro Mk3: choose the 1st port (e.g. `LPProMK3 MIDI` on Windows, `MK3 [hw:X:0:0]` or similar on Linux).
 * Pro, Mini Mk3, X: choose the 2nd port (e.g. *MIDIIN2 (Launchpad Pro)* and 
   *MIDIOUT2 (Launchpad Pro)* on Windows).
 * Make sure the Launchpad sends on Midi Channel 1!


### PR DESCRIPTION
I got lost because autodetect found my MK3 as a Mini. So I made a series of mistakes trying to fix this. I added the device manually, and it counts from :0 on linux... so I kept on adding the :1 device and getting confused. And I didn't see anything labeling any port as MIDI until I did `amidi -l` and spent a bunch of time going in circles, confused. Big fool energy, just trying to clarify for any future fools like me! :+1:

Don't know if you care about such tiny tweaks, but really appreciate the software. Am super loving way more customizability with this thing + Reaper.